### PR TITLE
Updating list of GNN-based models

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ A curated list of awesome resources dedicated to Relation Extraction, inspired b
     [[code]](https://github.com/XueFuzhao/GDPNet)
     * Fuzhao Xue, Aixin Sun, Hao Zhang, Eng Siong Chng
     * AAAI 21
+* RECON: Relation Extraction using Knowledge Graph Context in a Graph Neural Network
+    [[parer]](https://arxiv.org/pdf/2009.08694.pdf)
+    [[code]](https://github.com/ansonb/RECON)
+    * Anson Bastos, Abhishek Nadgeri, Kuldeep Singh, Isaiah Onando Mulang', Saeedeh Shekarpour, Johannes Hoffart, Manohar Kaul
+    * WWW'21
 	
 ### Distant Supervision Approaches
 * Distant supervision for relation extraction without labeled data [[paper]](https://web.stanford.edu/~jurafsky/mintz.pdf) [[review]](https://github.com/roomylee/paper-review/blob/master/relation_extraction/Distant_supervision_for_relation_extraction_without_labeled_data/review.md)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ A curated list of awesome resources dedicated to Relation Extraction, inspired b
     * Fuzhao Xue, Aixin Sun, Hao Zhang, Eng Siong Chng
     * AAAI 21
 * RECON: Relation Extraction using Knowledge Graph Context in a Graph Neural Network
-    [[parer]](https://arxiv.org/pdf/2009.08694.pdf)
+    [[parer]](https://arxiv.org/abs/2009.08694.pdf)
     [[code]](https://github.com/ansonb/RECON)
     * Anson Bastos, Abhishek Nadgeri, Kuldeep Singh, Isaiah Onando Mulang', Saeedeh Shekarpour, Johannes Hoffart, Manohar Kaul
     * WWW'21
@@ -149,10 +149,10 @@ A curated list of awesome resources dedicated to Relation Extraction, inspired b
 	* EMNLP 2018
 	
 ### Language Models
-* Enriching Pre-trained Language Model with Entity Information for Relation Classification [[paper]](https://arxiv.org/pdf/1905.08284.pdf)
+* Enriching Pre-trained Language Model with Entity Information for Relation Classification [[paper]](https://arxiv.org/abs/1905.08284.pdf)
     * Shanchan Wu, Yifan He
     * arXiv 2019
-* SpanBERT: Improving pre-training by representing and predicting spans [[paper]](https://arxiv.org/pdf/1907.10529.pdf) [[code]](https://github.com/facebookresearch/SpanBERT)
+* SpanBERT: Improving pre-training by representing and predicting spans [[paper]](https://arxiv.org/abs/1907.10529.pdf) [[code]](https://github.com/facebookresearch/SpanBERT)
     * Mandar Joshi, Danqi Chen, Yinhan Liu, Daniel S. Weld, Luke Zettlemoyer and Omer Levy
     * Transactions of the Association for Computational Linguistics 2020
 

--- a/README.md
+++ b/README.md
@@ -97,10 +97,20 @@ A curated list of awesome resources dedicated to Relation Extraction, inspired b
 * Neural Relation Extraction via Inner-Sentence Noise Reduction and Transfer Learning [[paper]](https://arxiv.org/abs/1808.06738)
 	* Tianyi Liu, Xinsong Zhang, Wanhao Zhou, Weijia Jia
 	* EMNLP 2018
+	
 #### GNN-based Models
+* Matching the Blanks: Distributional Similarity for Relation Learning [[paper]](https://arxiv.org/abs/1906.03158)
+    * Livio Baldini Soares, Nicholas FitzGerald, Jeffrey Ling, Tom Kwiatkowski
+    * ACL 2019
 * Relation of the Relations: A New Paradigm of the Relation Extraction Problem [[paper]](https://arxiv.org/abs/2006.03719)
 	* Zhijing Jin, Yongyi Yang, Xipeng Qiu, Zheng Zhang
 	* EMNLP 2020
+* GDPNet: Refining Latent Multi-View Graph for Relation Extraction 
+    [[paper]](https://arxiv.org/abs/2012.06780.pdf)
+    [[code]](https://github.com/XueFuzhao/GDPNet)
+    * Fuzhao Xue, Aixin Sun, Hao Zhang, Eng Siong Chng
+    * AAAI 21
+	
 ### Distant Supervision Approaches
 * Distant supervision for relation extraction without labeled data [[paper]](https://web.stanford.edu/~jurafsky/mintz.pdf) [[review]](https://github.com/roomylee/paper-review/blob/master/relation_extraction/Distant_supervision_for_relation_extraction_without_labeled_data/review.md)
 	* Mike Mintz, Steven Bills, Rion Snow and Dan Jurafsky


### PR DESCRIPTION
I found that you already declare the GNN section, because so far i decided to create the related one.
Providing a list of other gnn-based models.
In addition, i have fixed my prior arxiv references from the direct pdf's to abstracts.